### PR TITLE
Fix footer links and add missing pages

### DIFF
--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const PrivacyPage: React.FC = () => (
+  <div className="min-h-screen flex items-center justify-center bg-bg text-gray-200 p-8">
+    <div className="max-w-2xl">
+      <h1 className="text-3xl font-bold mb-4">Privacy Policy</h1>
+      <p>
+        We respect your privacy. No personal data is stored on our servers.
+        Any wallet addresses displayed are for illustrative purposes only.
+      </p>
+    </div>
+  </div>
+);
+
+export default PrivacyPage;

--- a/src/pages/risk-profile.tsx
+++ b/src/pages/risk-profile.tsx
@@ -73,15 +73,20 @@ const RiskProfilePage = () => {
           <footer className="mt-24 text-center text-gray-400 text-sm">
             <p>© 2025 KONNECT - Advanced Trading Platform</p>
             <div className="flex justify-center items-center space-x-6 mt-4">
-              <Link href="javascript:void(0);" className="hover:text-blue-400 transition-colors">
+              <Link href="/terms" className="hover:text-blue-400 transition-colors">
                 Terms
               </Link>
-              <Link href="javascript:void(0);" className="hover:text-blue-400 transition-colors">
+              <Link href="/privacy" className="hover:text-blue-400 transition-colors">
                 Privacy
               </Link>
-              <Link href="javascript:void(0);" className="hover:text-blue-400 transition-colors">
+              <a
+                href="https://docs.konstellation.tech"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-blue-400 transition-colors"
+              >
                 Documentation
-              </Link>
+              </a>
             </div>
           </footer>
         </div>

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const TermsPage: React.FC = () => (
+  <div className="min-h-screen flex items-center justify-center bg-bg text-gray-200 p-8">
+    <div className="max-w-2xl">
+      <h1 className="text-3xl font-bold mb-4">Terms & Privacy</h1>
+      <p>
+        This application is provided as-is for demonstration purposes. No warranty is provided.
+        Please review all terms and conditions carefully.
+      </p>
+    </div>
+  </div>
+);
+
+export default TermsPage;


### PR DESCRIPTION
## Summary
- fix footer links on the Risk Profile page
- add Terms and Privacy placeholder pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*
- `npm test` *(fails: jest not found)*